### PR TITLE
Ensure only signed session cookies are used

### DIFF
--- a/services/session-service.js
+++ b/services/session-service.js
@@ -31,7 +31,7 @@ function restoreSessionIfNeeded (req, res) {
   req.session = {}
 
   // TODO refresh cookies if they're getting close to expiry
-  let sessionCookie = req.cookies.get('session')
+  let sessionCookie = req.cookies.get('session', {signed: true})
   if (sessionCookie) {
     try {
       req.session = JSON.parse(sessionCookie)


### PR DESCRIPTION
Seems signed cookies also need to be loaded with `{signed: true}`.